### PR TITLE
Unpin dev-dependencies in pyproject.toml

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -14,22 +14,22 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 
 [tool.poetry.dev-dependencies]
-flake8 = "^3.7"
-flake8-commas = "^2.0"
-flake8-comprehensions = "^2.2"
-flake8-debugger = "^3.1"
-flake8-docstrings = "^1.4"
-flake8-isort = "^2.7"
-flake8-mutable = "^1.2"
-flake8-todo = "^0.7.0"
-mypy = "^0.720"
-pytest = "^5.1"
-pytest-cov = "^2.7"
-rope = "^0.14.0"
-isort = {version = "^4.3",extras = ["pyproject"]}
+flake8 = "*"
+flake8-commas = "*"
+flake8-comprehensions = "*"
+flake8-debugger = "*"
+flake8-docstrings = "*"
+flake8-isort = "*"
+flake8-mutable = "*"
+flake8-todo = "*"
+mypy = "*"
+pytest = "*"
+pytest-cov = "*"
+rope = "*"
+isort = {version = "*",extras = ["pyproject"]}
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Allowing poetry to pull in the latest versions of all tools should help keep the cookiecutter relevant, by preventing dev dependencies from becoming outdated.